### PR TITLE
tblastx filtering accounting for reading frames

### DIFF
--- a/exonize/exonize.py
+++ b/exonize/exonize.py
@@ -2,7 +2,7 @@ from .exonize_handler import *
 import argparse
 
 
-def exonize_asci_art() -> None:
+def exonize_ascii_art_logo() -> None:
     exonize_ansi_regular = """
     
     ███████╗██╗  ██╗ ██████╗ ███╗   ██╗██╗███████╗███████╗
@@ -45,7 +45,7 @@ def argument_parser():
 
 
 def main():
-    exonize_asci_art()
+    exonize_ascii_art_logo()
     args = argument_parser()
     exonize_obj = Exonize(gff_file_path=args.gff_file_path,
                           genome_path=args.genome_path,

--- a/exonize/exonize.py
+++ b/exonize/exonize.py
@@ -18,7 +18,8 @@ def exonize_ascii_art_logo() -> None:
           "Supervised by: Lars Arvestad, Mathematics Department, Stockholm University\n"
           "               & Liam Longo, Earth-Life Science Institute (ELSI), Tokyo Institute of Technology\n"
           "      Contact: marina.sarrias@math.su.se\n"
-          "       GitHub: https://github.com/msarrias/exonize")
+          "       GitHub: https://github.com/msarrias/exonize\n"
+          "\n")
 
 
 def argument_parser():

--- a/exonize/exonize.py
+++ b/exonize/exonize.py
@@ -2,6 +2,25 @@ from .exonize_handler import *
 import argparse
 
 
+def exonize_asci_art() -> None:
+    exonize_ansi_regular = """
+    
+    ███████╗██╗  ██╗ ██████╗ ███╗   ██╗██╗███████╗███████╗
+    ██╔════╝╚██╗██╔╝██╔═══██╗████╗  ██║██║╚══███╔╝██╔════╝
+    █████╗   ╚███╔╝ ██║   ██║██╔██╗ ██║██║  ███╔╝ █████╗
+    ██╔══╝   ██╔██╗ ██║   ██║██║╚██╗██║██║ ███╔╝  ██╔══╝
+    ███████╗██╔╝ ██╗╚██████╔╝██║ ╚████║██║███████╗███████╗
+    ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚══════╝╚══════╝
+        """
+    print(exonize_ansi_regular)
+    print("Exonize v1.0\n"
+          " Developed by: Marina Herrera Sarrias, Mathematics Department, Stockholm University\n"
+          "Supervised by: Lars Arvestad, Mathematics Department, Stockholm University\n"
+          "               & Liam Longo, Earth-Life Science Institute (ELSI), Tokyo Institute of Technology\n"
+          "      Contact: marina.sarrias@math.su.se\n"
+          "       GitHub: https://github.com/msarrias/exonize")
+
+
 def argument_parser():
     parser = argparse.ArgumentParser(description='Exonize Description')
     parser.add_argument('gff_file_path', type=str, help='Path to GFF file')
@@ -26,6 +45,7 @@ def argument_parser():
 
 
 def main():
+    exonize_asci_art()
     args = argument_parser()
     exonize_obj = Exonize(gff_file_path=args.gff_file_path,
                           genome_path=args.genome_path,

--- a/exonize/exonize_handler.py
+++ b/exonize/exonize_handler.py
@@ -303,6 +303,10 @@ class Exonize(object):
                              },...}},...}
         """
         def construct_mRNA_sequence(chrom_, strand_, coords_):
+            """
+            construct_mRNA_sequence is a function that constructs the mRNA sequence based on genomic coordinates of the
+            CDSs and the strand of the gene.
+            """
             seq = ''
             for coord_ in coords_:
                 start, end = coord_['coord'].lower, coord_['coord'].upper
@@ -313,6 +317,34 @@ class Exonize(object):
             return seq
 
         def construct_protein_sequence(gene_, trans_id_, mRNA_seq_, coords_):
+            """
+            Construct a protein sequence from transcriptomic coordinates and collect corresponding CDSs in both DNA and
+            protein formats.
+            Given the transcriptomic coordinates and considering the reading frames specified in a GFF file, this function
+            constructs a protein sequence while managing the intricacies of exon stitching and reading frame maintenance
+            across possibly intron-interrupted CDS regions.
+            In the context of a GFF file, feature coordinates are generally relative to the genomic sequence, which implies
+            that reading frames may be disrupted by introns.
+
+            Example:
+                Consider the following genomic coordinates of CDSs and their reading frames:
+                cds1: (0,127)      reading frame: 0
+                cds2: (4545,4682)  reading frame: 2
+                cds3: (6460,6589)  reading frame: 0
+                cds4: (7311,7442)  reading frame: 0
+
+                When translated to transcriptomic coordinates (while still referring to genomic positions), considering
+                reading frames, the coordinates become:
+                cds1: (0, 127), (4545, 4547)
+                cds2: (4547, 4682)
+                cds3: (6460, 6589)
+                cds4: (7311, 7442)
+
+                Note:
+                The first two nucleotides of cds2 complete the last codon of cds1, and thus, it is in line with the specified
+                reading frame of 2 for cds2.
+            This function, therefore, ensures accurate translation and splicing of CDSs by adhering to specified reading frames.
+            """
             CDs_temp_list_ = {}
             prot_seq_, temp, start_coord = '', [], 0
             for coord_idx, coord_ in enumerate(coords_):

--- a/exonize/exonize_handler.py
+++ b/exonize/exonize_handler.py
@@ -359,7 +359,7 @@ class Exonize(object):
             """
             CDs_temp_list_ = {}
             prot_seq_, temp, start_coord = '', [], 0
-            n_coords = len(coords_)-1
+            n_coords = len(coords_)
             for coord_idx, coord_ in enumerate(coords_):
                 frame = int(coord_['frame'])
                 s, e = coord_['coord'].lower, coord_['coord'].upper
@@ -1098,18 +1098,6 @@ class Exonize(object):
         - 13. The function creates the Exclusive_pairs view. This view contains all the events that follow the mutually exclusive
         category.
         """
-        def exonize_asci_art() -> None:
-            exonize_ansi_regular = """
-
-            ███████╗██╗  ██╗ ██████╗ ███╗   ██╗██╗███████╗███████╗
-            ██╔════╝╚██╗██╔╝██╔═══██╗████╗  ██║██║╚══███╔╝██╔════╝
-            █████╗   ╚███╔╝ ██║   ██║██╔██╗ ██║██║  ███╔╝ █████╗
-            ██╔══╝   ██╔██╗ ██║   ██║██║╚██╗██║██║ ███╔╝  ██╔══╝
-            ███████╗██╔╝ ██╗╚██████╔╝██║ ╚████║██║███████╗███████╗
-            ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝╚══════╝╚══════╝
-            """
-            print(exonize_ansi_regular)
-
         def batch(iterable: list, n=1) -> list:
             """
             batch is a function that given a list and a batch size, returns an iterable of lists of size n.
@@ -1118,7 +1106,6 @@ class Exonize(object):
             for indx in range(0, it_length, n):
                 yield iterable[indx:min(indx + n, it_length)]
 
-        exonize_asci_art()
         self.prepare_data()
         args_list = list(self.gene_hierarchy_dict.keys())
         processed_gene_ids = query_gene_ids_in_res_db(self.results_db, self.timeout_db)

--- a/exonize/exonize_handler.py
+++ b/exonize/exonize_handler.py
@@ -82,7 +82,6 @@ class Exonize(object):
             self.remove_file_if_exists(self.results_db)
         elif self._SOFT_FORCE:
             self.remove_file_if_exists(self.results_db)
-        print(self._DEBUG_MODE)
 
     # noinspection PyProtectedMember
     def file_only_info(self, message, *args, **kws):
@@ -464,7 +463,6 @@ class Exonize(object):
             sequence (CDS) and gene_id_ is the identifier of the target sequence (gene).
             - output: output/{ident}_output.xml where ident is the identifier of the query sequence (CDS).
             """
-
             output_file = f'output/{ident}_output.xml'
             if not os.path.exists(output_file):
                 query_filename = f'input/{ident}_query.fa'
@@ -649,18 +647,16 @@ class Exonize(object):
         """
         def check_for_masking(chrom_: str, gene_id_: str, seq_: str, type_='gene'):
             """
-            check_for_masking is a function that retrieves a gene/CDS sequence from the genome and checks
-            if it is hardmasked. If the sequence is a gene and the percentage of hardmasking is greater than the
-            threshold (self.masking_perc_threshold) the CDS duplication search is aborted and the gene is recorded
-            as having no duplication event. If the sequence is a CDS and the percentage of hardmasking is greater than
-            the threshold, the CDS is not queried. Logs for hardmasked genes and CDS are stored in the logs attribute
-            and later dumped into a file.
+            check_for_masking is a function that checks if it is hardmasked. If the sequence is a gene and the percentage
+            of hardmasking is greater than the threshold (self.masking_perc_threshold) the CDS duplication search is aborted
+            and the gene is recorded as having no duplication event. If the sequence is a CDS and the percentage of
+            hardmasking is greater than the threshold, the CDS is not queried. Logs for hardmasked genes and CDS are stored
+            in the logs attribute and later dumped into a file.
             :param chrom_: chromosome identifier
             :param gene_id_: gene identifier
             :param seq_: sequence
             :param type_: type of sequence (gene or CDS)
             """
-
             def sequence_masking_percentage(seq: str) -> float:
                 """
                 sequence_masking_percentage is a function that given a sequence, returns the percentage of hardmasking

--- a/exonize/exonize_handler.py
+++ b/exonize/exonize_handler.py
@@ -325,7 +325,7 @@ class Exonize(object):
             across possibly intron-interrupted CDS regions.
             In the context of a GFF file, feature coordinates are generally relative to the genomic sequence, which implies
             that reading frames may be disrupted by introns.
-
+            ----------------
             Example:
                 Consider the following genomic coordinates of CDSs and their reading frames:
                 cds1: (0,127)      reading frame: 0
@@ -339,8 +339,8 @@ class Exonize(object):
                 cds2: (4547, 4682)
                 cds3: (6460, 6589)
                 cds4: (7311, 7442)
-
-                Note:
+            ----------------
+            Note:
                 The first two nucleotides of cds2 complete the last codon of cds1, and thus, it is in line with the specified
                 reading frame of 2 for cds2.
             This function, therefore, ensures accurate translation and splicing of CDSs by adhering to specified reading frames.
@@ -362,7 +362,8 @@ class Exonize(object):
                 CDs_temp_list_[coord_['id']] = dict(frame=frame, coord=P.open(s, e), dna_seq=exon_seq, pep_seq=exon_prot)
             if max(temp) > 0:
                 if not (temp[-1] != 0) and all(item == 0 for item in temp[:-1]):
-                    print(f'check here: {gene_}, {trans_id_}')
+                    self.logger.error(f'check here: {gene_}, {trans_id_}')
+                    sys.exit()
             return prot_seq_, CDs_temp_list_
 
         self.gene_hierarchy_dict = {}

--- a/exonize/sqlite_utils.py
+++ b/exonize/sqlite_utils.py
@@ -38,6 +38,7 @@ def connect_create_results_db(db_path: str, timeout_db: int) -> None:
         gene_id  VARCHAR(100) NOT NULL,
         CDS_start INTEGER NOT NULL,
         CDS_end INTEGER NOT NULL,  
+        CDS_frame VARCHAR NOT NULL,
         query_frame INTEGER NOT NULL,
         query_strand VARCHAR(1) NOT NULL,
         target_frame INTEGER NOT NULL,
@@ -288,6 +289,7 @@ def insert_fragments_calls() -> tuple:
     gene_id,
     CDS_start,
     CDS_end,
+    CDS_frame,
     query_frame,
     query_strand,
     target_frame,
@@ -306,7 +308,7 @@ def insert_fragments_calls() -> tuple:
     query_num_stop_codons,
     target_num_stop_codons
     )
-    VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
     insert_gene_table_param = """
     INSERT INTO Genes
@@ -789,3 +791,15 @@ def create_exclusive_pairs_view(db_path: str, timeout_db: int) -> None:
         ORDER BY fm3.fragment_id, target, query;
         """)
         db.commit()
+
+#
+# SELECT f.fragment_id, f.gene_id, g.gene_strand, f.CDS_start, f.CDS_end, f.query_start , f.query_end,  f.target_start,
+# f.target_end, f.query_frame qf, f.query_strand qs ,f.target_frame as tf, f.target_strand ts, f.query_dna_seq as qdnq,
+# f.target_dna_seq as tdna FROM Fragments as f
+# inner join Genes as g on f.gene_id=g.gene_id
+# where f.gene_id=="ENSG00000130635";
+# limit 100;
+# where gene_id=="ENSG00000172348"
+#
+#
+# LIMIT 10;

--- a/exonize/sqlite_utils.py
+++ b/exonize/sqlite_utils.py
@@ -791,15 +791,3 @@ def create_exclusive_pairs_view(db_path: str, timeout_db: int) -> None:
         ORDER BY fm3.fragment_id, target, query;
         """)
         db.commit()
-
-#
-# SELECT f.fragment_id, f.gene_id, g.gene_strand, f.CDS_start, f.CDS_end, f.query_start , f.query_end,  f.target_start,
-# f.target_end, f.query_frame qf, f.query_strand qs ,f.target_frame as tf, f.target_strand ts, f.query_dna_seq as qdnq,
-# f.target_dna_seq as tdna FROM Fragments as f
-# inner join Genes as g on f.gene_id=g.gene_id
-# where f.gene_id=="ENSG00000130635";
-# limit 100;
-# where gene_id=="ENSG00000172348"
-#
-#
-# LIMIT 10;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 name = "Exonize"
 description = "Find duplicated exons"
 authors = [
-	{name = "Lars Arvestad", email = "marina.sarrias_at_math.su.se"},
-	{name = "Liam Longo", email = "llongo_at_elsi.jp"},
-	{name = "Marina Herrera Sarrias", email = "marina.sarrias_at_math.su.se"}
+	{name = "Lars Arvestad", email = "arvestad@math.su.se"},
+	{name = "Liam Longo", email = "llongo@elsi.jp"},
+	{name = "Marina Herrera Sarrias", email = "marina.sarrias@math.su.se"}
 ]
 maintainers = [
-	{name = "Marina Herrera Sarrias", email = "marina.sarrias_at_math.su.se"},
-	{name = "Lars Arvestad", email = "marina.sarrias_at_math.su.se"}
+	{name = "Marina Herrera Sarrias", email = "marina.sarrias@math.su.se"},
+	{name = "Lars Arvestad", email = "arvestad@math.su.se"}
 ]
 version = "0.1"
 dependencies = [
@@ -20,7 +20,5 @@ dependencies = [
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
-
-
 [project.scripts]
 exonize = "exonize.exonize:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,14 @@
 name = "Exonize"
 description = "Find duplicated exons"
 authors = [
-       {name = "Marina Herrera Sarrias", email = "marina.sarrias@math.su.se"}
-       ]
+    "Marina Herrera Sarrias <marina.sarrias_at_math.su.se>",
+	"Lars Arvestad <arvestad_at_math.su.se>",
+	"Liam Longo <llongo_at_elsi.jp>"
+]
+maintainers = [
+	"Marina Herrera Sarrias <marina.sarrias_at_math.su.se>",
+	"Lars Arvestad <arvestad_at_math.su.se>"
+]
 version = "0.1"
 dependencies = [
 	     "gffutils>=0.11.1",
@@ -11,7 +17,6 @@ dependencies = [
 	     "portion>=2.4.0",
 	     "biopython>=1.81",
 ]
-
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 name = "Exonize"
 description = "Find duplicated exons"
 authors = [
-	"Marina Herrera Sarrias <marina.sarrias_at_math.su.se>",
-	"Lars Arvestad <arvestad_at_math.su.se>",
-	"Liam Longo <llongo_at_elsi.jp>"
+	{name = "Lars Arvestad", email = "marina.sarrias_at_math.su.se"},
+	{name = "Liam Longo", email = "llongo_at_elsi.jp"},
+	{name = "Marina Herrera Sarrias", email = "marina.sarrias_at_math.su.se"}
 ]
 maintainers = [
-	"Marina Herrera Sarrias <marina.sarrias_at_math.su.se>",
-	"Lars Arvestad <arvestad_at_math.su.se>"
+	{name = "Marina Herrera Sarrias", email = "marina.sarrias_at_math.su.se"},
+	{name = "Lars Arvestad", email = "marina.sarrias_at_math.su.se"}
 ]
 version = "0.1"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "Exonize"
 description = "Find duplicated exons"
 authors = [
-    "Marina Herrera Sarrias <marina.sarrias_at_math.su.se>",
+	"Marina Herrera Sarrias <marina.sarrias_at_math.su.se>",
 	"Lars Arvestad <arvestad_at_math.su.se>",
 	"Liam Longo <llongo_at_elsi.jp>"
 ]


### PR DESCRIPTION
## The criteria for filtering the` tblastx` hits are the following:

1. **Minimum Query Alignment Coverage:** Retain hits that have at least 90% query alignment coverage.
2. **Reading Frame:** Only keep hits where the reading frame of the query CDS matches the hit query reading frame.
3. **Handling Overlaps with Preference:** For hits sharing the same query CDS and having overlapping target coordinates:
- Favor hits that are in the same strand as the gene. 
- Among those, prioritize hits with the lowest e-value.

## Extra info for understanding CDS genomic coordinates and reading frames in GFF files:

Consider a mRNA sequence composed of several CDSs.

**genomic coordinates**
```
mRNA_1
cds1_1: (0,127)      reading frame: 0
cds2_1: (4545,4682)  reading frame: 2 --> the initial two nucleotides of cds2 complete the last codon of cds1
cds3_1: (6460,6589)  reading frame: 0
cds4_1: (7311,7442)  reading frame: 0
```

If we now account for the reading frames, the CDS coordinates adjust to:
**transcriptomic coordinates**
```
mRNA_1
cds1_1: (0, 127), (4545, 4547) 
cds2_1: (4547, 4682)           
cds3_1: (6460, 6589)           
cds4_1: (7311, 7442)   
```        
Now, let's consider a second mRNA transcript associated with the same gene:
**genomic coordinates**
```
mRNA_2
cds1_2: (0,127)      reading frame: 0
cds3_2: (6460,6589)  reading frame: 2
cds4_2: (7311,7442)  reading frame: 2
```
**transcriptomic coordinates**
```
mRNA_2
cds1_2: (0, 127), (6460, 6462)         
cds3_2: (6462, 6589),(7311, 7313)      
cds4_2: (7313, 7442)   
```  

**Take away message:**

- When considering different CDSs that share genomic coordinates, if the CDSs are affected by alternative splicing events, they might exhibit differences in their transcriptomic sequences. (For obligate cases, it would be interesting to check the reading frames of the CDSs in question, as they might yield different sequences at the protein level).


**On another note...**

Another thing that has me confused is that if the transcript sequence is not divisible by three, it is always the case (at least for humans) that the last CDS has some extra nucleotides.  I really don't understand this. (wild guess) Is this because those extra nucleotides would account for the "completion" of other mRNA transcripts?  By saying this I'm assuming that the last CDS is always present in all transcripts and therefore has the task of "completing" preceding CDSs. A half-baked attempt to convince myself that those loose nucleotides accomplish a function.

The previous is a good example of this:
```
mRNA1
cds1_1: (0, 127), (4545, 4547) length: 127 + 2  % 3: 0
cds2_1: (4547, 4682)           length: 135 % 3: 0
cds3_1: (6460, 6589)           length: 129 % 3: 0
cds4_1: (7311, 7442)           length: 131 % 3 : 2 
```

```
mRNA2
cds1_2: (0, 127), (4545, 4547) length: 129 % 3: 0
cds3_2: (6462, 6589),(7311, 7313)                length: 129 % 3: 0
cds4_2: (7313, 7442)           length: 129 % 3 : 2 
```